### PR TITLE
Travis CI: Add automated testing for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+matrix:
+  allow_failures:
+    - python: 3.7
+  include:
+    - python: 2.7
+    #- python: 3.4
+    #- python: 3.5
+    #- python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Replaces #39.  You would need to log into https://travis-ci.com with your GitHub credentials and go for the free plan.