### PR TITLE
Can we remove ./lib and pip install requirements instead?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ install:
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --exclude=./lib --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exclude=./lib --exit-zero --max-complexity=10 --max-line-length=127 --statistics --quiet
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --quiet
 script:
   - true  # add other tests here
 notifications:


### PR DESCRIPTION
There are a lot of Python 3 issues in the code of the _vendored in_ modules in the __./lib__ directory.